### PR TITLE
Add missing include

### DIFF
--- a/NBodySimulation/utils.h
+++ b/NBodySimulation/utils.h
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <algorithm>
+#include <intrin.h>
 
 #define force_inline __forceinline
 #define StaticAssert(e) extern char (*ct_assert(void)) [sizeof(char[1 - 2*!(e)])]


### PR DESCRIPTION
The intrinsic `__cpuid` is defined in the header `intrin.h`